### PR TITLE
chore: update request-ip to v3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "debug": "4.3.4",
     "lodash.isplainobject": "4.0.6",
-    "request-ip": "2.1.3"
+    "request-ip": "^3.3.0"
   },
   "devDependencies": {
     "eslint-config-standard": "17.0.0",


### PR DESCRIPTION
update `request-ip` to latest version. previous version had a dependency on `is_js` which has a known vulnerabilities for ReDoS(Regular Expression Denial of Service)